### PR TITLE
Update CameraActivity.java

### DIFF
--- a/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/CameraActivity.java
+++ b/lite/examples/object_detection/android/app/src/main/java/org/tensorflow/lite/examples/detection/CameraActivity.java
@@ -346,8 +346,7 @@ public abstract class CameraActivity extends AppCompatActivity
       final int requestCode, final String[] permissions, final int[] grantResults) {
     if (requestCode == PERMISSIONS_REQUEST) {
       if (grantResults.length > 0
-          && grantResults[0] == PackageManager.PERMISSION_GRANTED
-          && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
+          && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
         setFragment();
       } else {
         requestPermission();


### PR DESCRIPTION
There is a leftover from the old version where the storage permission was needed so, now it is only one permission camera so grantResults[1] is out of range.